### PR TITLE
Chain to Flycheck’s built-in proselint checker

### DIFF
--- a/flycheck-languagetool.el
+++ b/flycheck-languagetool.el
@@ -250,7 +250,8 @@ CALLBACK is passed from Flycheck."
   :start #'flycheck-languagetool--start
   :enabled #'flycheck-languagetool--enabled
   :verify #'flycheck-languagetool--verify
-  :modes flycheck-languagetool-active-modes)
+  :modes flycheck-languagetool-active-modes
+  :next-checkers '(proselint))
 
 (add-to-list 'flycheck-checkers 'languagetool)
 


### PR DESCRIPTION
The proselint linter checks for different things to LanguageTool, so people may want to have both.