### PR TITLE
[WiP] Added a prog mode to flycheck-languagetool

### DIFF
--- a/flycheck-languagetool.el
+++ b/flycheck-languagetool.el
@@ -143,6 +143,9 @@ or plan to start a local server some other way."
 These rules will be disabled if Emacs’ `flyspell-mode' or
 `jinx-mode' is active.")
 
+(defconst flycheck-languagetool--prog-rules
+  '("COMMA_PARENTHESIS_WHITESPACE"))
+
 ;;
 ;; (@* "External" )
 ;;
@@ -160,6 +163,47 @@ These rules will be disabled if Emacs’ `flyspell-mode' or
   "Return column at PT."
   (unless pt (setq pt (point)))
   (save-excursion (goto-char pt) (current-column)))
+
+;;
+;; (@* "Prog Mode" )
+;;
+
+(defvar flycheck-languagetool--text-mode t)
+
+(defcustom flycheck-languagetool-prog-text-faces
+  (if (bound-and-true-p tree-sitter-hl-mode)
+      '(tree-sitter-hl-face:comment tree-sitter-hl-face:doc tree-sitter-hl-face:string)
+    '(font-lock-string-face font-lock-comment-face font-lock-doc-face))
+  "Faces corresponding to text in programming-mode buffers."
+  :type '(repeat (const font-lock-string-face)))
+
+(defun flycheck-languagetool--generic-progmode-verify (pt-beg pt-end)
+  "Used for `flycheck-languagetool-generic-check-word-predicate'.
+This predicate checks that the word between PT-BEG and PT-END has
+a \"text\" face in programming modes."
+  (unless (eql pt-beg pt-end)
+    ;; (point) is next char after the word. Must check one char before.
+    (let ((f (get-text-property (1- pt-end) 'face)))
+      (memq f flycheck-languagetool-prog-text-faces))))
+
+(defun flycheck-languagetool-flycheck-add-mode (mode)
+  "Register flycheck languagetool support for MODE."
+  (unless (flycheck-checker-supports-major-mode-p 'languagetool mode)
+    (flycheck-add-mode 'languagetool mode)))
+
+;;;###autoload
+(defun flycheck-languagetool-flycheck-enable ()
+  "Enable flycheck languagetool integration for the current buffer.
+This adds languagetool as the next checker of the main checker
+of the current buffer"
+  (interactive)
+  (require 'flycheck)
+  (flycheck-mode 1)
+  (flycheck-stop)
+  (flycheck-languagetool-flycheck-add-mode major-mode)
+  (add-to-list 'flycheck-checkers 'languagetool)
+  (setq flycheck-languagetool--text-mode nil)
+  (flycheck-add-next-checker (flycheck-get-checker-for-buffer) 'languagetool))
 
 ;;
 ;; (@* "Core" )
@@ -182,10 +226,11 @@ These rules will be disabled if Emacs’ `flyspell-mode' or
              (desc (cdr (assoc 'message match)))
              (col-start (flycheck-languagetool--column-at-pos pt-beg))
              (col-end (flycheck-languagetool--column-at-pos pt-end)))
-        (push (list ln col-start type desc
-                    :end-column col-end
-                    :id (cons id subid))
-              check-list)))
+        (when (or flycheck-languagetool--text-mode (flycheck-languagetool--generic-progmode-verify pt-beg pt-end))
+          (push (list ln col-start type desc
+                      :end-column col-end
+                      :id (cons id subid))
+                check-list))))
     check-list))
 
 (defun flycheck-languagetool--read-results (status source-buffer callback)
@@ -255,6 +300,8 @@ CALLBACK is passed from Flycheck."
           (flatten-tree (list
                          (cdr (assoc "disabledRules"
                                      flycheck-languagetool-check-params))
+                         (unless flycheck-languagetool--text-mode
+                           flycheck-languagetool--prog-rules)
                          (when (or (bound-and-true-p flyspell-mode)
                                    (bound-and-true-p jinx-mode))
                            flycheck-languagetool--spelling-rules))))
@@ -370,6 +417,7 @@ CALLBACK is passed from Flycheck."
 (defun flycheck-languagetool-setup ()
   "Setup flycheck-package."
   (interactive)
+  (setq flycheck-languagetool--text-mode t)
   (add-to-list 'flycheck-checkers 'languagetool))
 
 (provide 'flycheck-languagetool)


### PR DESCRIPTION
This is done by filtering out the errors that don't point to a place that has not a comment, a string or a doc face. The checker is added as the next checker of the main flycheck checker for the current mode

I still have some issues as to when the function `flycheck-languagetool-flycheck-enable` has to be used

In my current setup what I did is:

```elisp
  (use-package flycheck-languagetool
    :load-path "lisp/flycheck-languagetool/"
    ;; :custom ((flycheck-languagetool-active-modes
    ;;           '(text-mode latex-mode org-mode markdown-mode message-mode prog-mode)))
    :hook ((text-mode . flycheck-languagetool-setup)
           (lsp-mode . (lambda () (lsp-diagnostics-mode 1)
                         (require 'flycheck-languagetool)
                         (flycheck-languagetool-flycheck-enable))))
    ;; :ensure-system-package
    ;;   ("LanguageTool-5.9-stable/languagetool-commandline.jar" . "curl -L https://raw.githubusercontent.com/languagetool-org/languagetool/master/install.sh | sudo bash -a")
    :init
    (setq flycheck-languagetool-server-jar (expand-file-name "~/.emacs.d/LanguageTool-5.9-stable/languagetool-server.jar"))
    )
```

But this is not really good.

The issue is that if languagetool is added as a checker before the main-mode finished loading, it's not added as a next checker for the main one and the function needs to be called again.

Fixes #22 

If this seems good for you, I think an improvement would be to define a predicate function

This would allow to define different predicates for different modes (prog-mode don't have the same predicates as org-mode or markdown-mode for example)