### PR TITLE
Fix destructive mutation of flycheck-languagetool-check-params

### DIFF
--- a/flycheck-languagetool.el
+++ b/flycheck-languagetool.el
@@ -270,7 +270,7 @@ CALLBACK is passed from Flycheck."
                                    (bound-and-true-p jinx-mode))
                            flycheck-languagetool--spelling-rules))))
          (other-params (assoc-delete-all "disabledRules"
-                                         flycheck-languagetool-check-params))
+                                         (copy-alist flycheck-languagetool-check-params)))
          (url-request-data
           (mapconcat
            (lambda (param)


### PR DESCRIPTION
## Summary

- `assoc-delete-all` is destructive: it modifies the list in place. This means that every time a check runs, the `disabledRules` entry is permanently removed from `flycheck-languagetool-check-params`, causing any user customization of disabled rules to be lost after the first check.
- Fix: use `copy-alist` so that `assoc-delete-all` operates on a copy instead of the original value.

## Steps to reproduce

1. Set `flycheck-languagetool-check-params` to `'(("level" . "picky") ("disabledRules" . "ARROWS,DASH_RULE"))`.
2. Open a file and trigger a LanguageTool check.
3. Evaluate `flycheck-languagetool-check-params` — the `disabledRules` entry is gone, leaving only `(("level" . "picky"))`.