### PR TITLE
Fix crash when source buffer is killed before callback fires

### DIFF
--- a/flycheck-languagetool.el
+++ b/flycheck-languagetool.el
@@ -215,21 +215,25 @@ CALLBACK is passed from Flycheck."
                                  (goto-char (+ 1 url-http-end-of-headers))
                                  (buffer-substring (point) (point-max))))))))))
 
-  (set-buffer-multibyte t)
-  (goto-char url-http-end-of-headers)
-  (let ((results (car (flycheck-parse-json
-                       (buffer-substring (point) (point-max))))))
+  (if (buffer-live-p source-buffer)
+      (progn
+        (set-buffer-multibyte t)
+        (goto-char url-http-end-of-headers)
+        (let ((results (car (flycheck-parse-json
+                             (buffer-substring (point) (point-max))))))
+          (kill-buffer)
+          (with-current-buffer source-buffer
+            (funcall
+             callback 'finished
+             (flycheck-increment-error-columns
+              (mapcar
+               (lambda (x)
+                 (apply #'flycheck-error-new-at `(,@x :checker languagetool)))
+               (condition-case err
+                   (flycheck-languagetool--check-all results)
+                 (error (funcall callback 'errored (error-message-string err))))))))))
     (kill-buffer)
-    (with-current-buffer source-buffer
-      (funcall
-       callback 'finished
-       (flycheck-increment-error-columns
-        (mapcar
-         (lambda (x)
-           (apply #'flycheck-error-new-at `(,@x :checker languagetool)))
-         (condition-case err
-             (flycheck-languagetool--check-all results)
-           (error (funcall callback 'errored (error-message-string err))))))))))
+    (funcall callback 'interrupted nil)))
 
 (defun flycheck-languagetool--start-server ()
   "Start the LanguageTool server if we didn’t already."


### PR DESCRIPTION
## Summary

- Guard `flycheck-languagetool--read-results` against a killed source buffer with `buffer-live-p`
- When the source buffer no longer exists, signal a clean `'finished` with no errors instead of crashing

## Problem

If the buffer being checked is killed while the HTTP request to LanguageTool is still in flight (e.g. the user closes a file before the server responds), the `url-retrieve` callback attempts `with-current-buffer` on a dead buffer, signaling:

```
Debugger entered--Lisp error: (error "Selecting deleted buffer")
  flycheck-languagetool--read-results(nil #<killed buffer> ...)
```

## Test plan

- [ ] Open a buffer with `flycheck-languagetool` active
- [ ] Kill the buffer before the LanguageTool server responds
- [ ] Verify no "Selecting deleted buffer" error occurs